### PR TITLE
Ability to configure the EditorBrowsable state

### DIFF
--- a/Obsolete.Fody/AttributeFixer.cs
+++ b/Obsolete.Fody/AttributeFixer.cs
@@ -52,10 +52,7 @@ public partial class ModuleWeaver
         ValidateVersion(memberDefinition, attributeData);
 
         AddObsoleteAttribute(attributeData, customAttributes);
-        if (HideObsoleteMembers)
-        {
-            AddEditorBrowsableAttribute(customAttributes);
-        }
+        AddEditorBrowsableAttribute(customAttributes, HideObsoleteMembers);
     }
 
     static bool ThrowsNotImplemented(PropertyDefinition propertyDefinition)

--- a/Obsolete.Fody/BrowsableAttributeAdder.cs
+++ b/Obsolete.Fody/BrowsableAttributeAdder.cs
@@ -4,13 +4,15 @@ using Mono.Collections.Generic;
 
 public partial class ModuleWeaver
 {
-    public void AddEditorBrowsableAttribute(Collection<CustomAttribute> customAttributes)
+    public void AddEditorBrowsableAttribute(Collection<CustomAttribute> customAttributes, HideObsoleteMembersState state)
     {
-        if (customAttributes.Any(x => x.AttributeType.Name == "EditorBrowsableAttribute"))
+        if (customAttributes.Any(x => x.AttributeType.Name == "EditorBrowsableAttribute") || state == HideObsoleteMembersState.Off)
         {
             return;
         }
-        var customAttribute = new CustomAttribute(EditorBrowsableConstructor);        var customAttributeArgument = new CustomAttributeArgument(EditorBrowsableStateType, AdvancedStateConstant);        customAttribute.ConstructorArguments.Add(customAttributeArgument);
+        var customAttribute = new CustomAttribute(EditorBrowsableConstructor);
+        var customAttributeArgument = new CustomAttributeArgument(EditorBrowsableStateType, state == HideObsoleteMembersState.Advanced ? AdvancedStateConstant : NeverStateConstant);
+        customAttribute.ConstructorArguments.Add(customAttributeArgument);
         customAttributes.Add(customAttribute);
     }
 }

--- a/Obsolete.Fody/ConfigReader.cs
+++ b/Obsolete.Fody/ConfigReader.cs
@@ -10,7 +10,7 @@ public partial class ModuleWeaver
     public string ThrowsNotImplementedText = "The member currently throws a NotImplementedException. ";
     public string ReplacementFormat = "Use `{0}` instead. ";
 
-    public bool HideObsoleteMembers = true;
+    public HideObsoleteMembersState HideObsoleteMembers = HideObsoleteMembersState.Advanced;
 
     public void ReadConfig()
     {
@@ -52,8 +52,10 @@ public partial class ModuleWeaver
         {
             return;
         }
-        if (bool.TryParse(xAttribute.Value, out HideObsoleteMembers))
+
+        if (Enum.TryParse<HideObsoleteMembersState>(xAttribute.Value, true, out var state))
         {
+            HideObsoleteMembers = state;
             return;
         }
         throw new Exception($"Could not parse 'HideObsoleteMembers' from '{xAttribute.Value}'.");

--- a/Obsolete.Fody/EditorBrowsableAttributeFinder.cs
+++ b/Obsolete.Fody/EditorBrowsableAttributeFinder.cs
@@ -6,18 +6,21 @@ public partial class ModuleWeaver
     public MethodReference EditorBrowsableConstructor;
     public TypeDefinition EditorBrowsableStateType;
     public int AdvancedStateConstant;
+    public int NeverStateConstant;
 
     void FindEditorBrowsableTypes()
     {
-        if (!HideObsoleteMembers)
+        if (HideObsoleteMembers == HideObsoleteMembersState.Off)
         {
             return;
         }
         var attributeType = FindTypeDefinition("System.ComponentModel.EditorBrowsableAttribute");
         EditorBrowsableConstructor = ModuleDefinition.ImportReference(attributeType.Methods.First(IsDesiredConstructor));
         EditorBrowsableStateType = FindTypeDefinition("System.ComponentModel.EditorBrowsableState");
-        var fieldDefinition = EditorBrowsableStateType.Fields.First(x => x.Name == "Advanced");
-        AdvancedStateConstant = (int) fieldDefinition.Constant;
+        var advancedFieldDefinition = EditorBrowsableStateType.Fields.First(x => x.Name == "Advanced");
+        AdvancedStateConstant = (int) advancedFieldDefinition.Constant;
+        var neverFieldDefinition = EditorBrowsableStateType.Fields.First(x => x.Name == "Never");
+        NeverStateConstant = (int) neverFieldDefinition.Constant;
     }
 
     static bool IsDesiredConstructor(MethodDefinition x)
@@ -31,5 +34,16 @@ public partial class ModuleWeaver
             return false;
         }
         return x.Parameters[0].ParameterType.Name == "EditorBrowsableState";
+    }
+
+    public enum HideObsoleteMembersState
+    {
+        Advanced,
+        // some dirty trickery to be backward compatible
+        True = Advanced,
+        Never,
+        Off,
+        // some dirty trickery to be backward compatible
+        False = Off,
     }
 }

--- a/Tests/ConfigReaderTests.cs
+++ b/Tests/ConfigReaderTests.cs
@@ -5,18 +5,6 @@ using Xunit;
 public class ConfigReaderTests
 {
     [Fact]
-    public void TrueHideObsoleteMembers()
-    {
-        var xElement = XElement.Parse(@"<Obsolete HideObsoleteMembers='true'/>");
-        var moduleWeaver = new ModuleWeaver
-        {
-            Config = xElement
-        };
-        moduleWeaver.ReadConfig();
-        Assert.True(moduleWeaver.HideObsoleteMembers);
-    }
-
-    [Fact]
     public void ThrowsNotImplementedText()
     {
         var xElement = XElement.Parse(@"<Obsolete ThrowsNotImplementedText='Custom Text'/>");
@@ -28,18 +16,28 @@ public class ConfigReaderTests
         Assert.Equal("Custom Text", moduleWeaver.ThrowsNotImplementedText);
     }
 
-    [Fact]
-    public void FalseHideObsoleteMembers()
+    [Theory]
+    [InlineData("false", ModuleWeaver.HideObsoleteMembersState.Off)]
+    [InlineData("False", ModuleWeaver.HideObsoleteMembersState.Off)]
+    [InlineData("true", ModuleWeaver.HideObsoleteMembersState.Advanced)]
+    [InlineData("True", ModuleWeaver.HideObsoleteMembersState.Advanced)]
+    [InlineData("advanced", ModuleWeaver.HideObsoleteMembersState.Advanced)]
+    [InlineData("Advanced", ModuleWeaver.HideObsoleteMembersState.Advanced)]
+    [InlineData("never", ModuleWeaver.HideObsoleteMembersState.Never)]
+    [InlineData("Never", ModuleWeaver.HideObsoleteMembersState.Never)]
+    [InlineData("off", ModuleWeaver.HideObsoleteMembersState.Off)]
+    [InlineData("Off", ModuleWeaver.HideObsoleteMembersState.Off)]
+    public void HideObsoleteMembers(string state, ModuleWeaver.HideObsoleteMembersState expected)
     {
-        var xElement = XElement.Parse(@"<Obsolete HideObsoleteMembers='false'/>");
+        var xElement = XElement.Parse($"<Obsolete HideObsoleteMembers='{state}'/>");
         var moduleWeaver = new ModuleWeaver
         {
             Config = xElement
         };
         moduleWeaver.ReadConfig();
-        Assert.False(moduleWeaver.HideObsoleteMembers);
+        Assert.Equal(expected, moduleWeaver.HideObsoleteMembers);
     }
-
+    
     [Fact]
     public void EmptyHideObsoleteMembers()
     {
@@ -49,7 +47,7 @@ public class ConfigReaderTests
             Config = xElement
         };
         moduleWeaver.ReadConfig();
-        Assert.True(moduleWeaver.HideObsoleteMembers);
+        Assert.Equal(ModuleWeaver.HideObsoleteMembersState.Advanced, moduleWeaver.HideObsoleteMembers);
     }
 
     [Fact]

--- a/readme.md
+++ b/readme.md
@@ -120,9 +120,13 @@ All configuration options are access by modifying the `Obsolete` node in `FodyWe
 
 ### HideObsoleteMembers
 
-When this is `true` obsolete members will also have `[EditorBrowsable(EditorBrowsableState.Advanced)]` added to them.
+When this is `advanced` or `true` obsolete members will also have `[EditorBrowsable(EditorBrowsableState.Advanced)]` added to them.
 
-*Defaults to `true`*
+*Defaults to `advanced`*
+
+When this is `never` obsolete members will also have `[EditorBrowsable(EditorBrowsableState.Never)]` added to them.
+
+When this is `off` or `false` obsolete members will not have `[EditorBrowsable]` added to them.
 
 ```xml
 <Obsolete HideObsoleteMembers='false'/>


### PR DESCRIPTION
As [discussed on twitter](https://twitter.com/SimonCropp/status/1491327993536716802) I'm contributing the possibility to switch the browsable state

#### You should already be a Patron

**It is expected that all developers using Fody either [become a Patron on OpenCollective](https://opencollective.com/fody/contribute/patron-3059), or have a [Tidelift Subscription](https://tidelift.com/subscription/pkg/nuget-fody?utm_source=nuget-fody&utm_medium=referral&utm_campaign=enterprise). [See Licensing/Patron FAQ](https://github.com/Fody/Home/blob/master/pages/licensing-patron-faq.md) for more information.** With that in mind, it is assumed anyone raising a PR is already a Patron. As such your GitHub Id may be verified against the [OpenCollective contributors](https://opencollective.com/fody#contributors). This process will depend on the PR quality, your circumstances, and the impact on the larger user base.

I think Particular is a Patron


#### Guidance

If you are uncertain if the PR will be accepted, outline the proposal in an issue to confirm it is viable.

Even if the feature is a good idea and viable, it may not be accepted since the ongoing effort in maintaining the feature may outweigh the benefit it delivers.


#### Description

This enables switching the `EditorBrowsable` state based on the configuration value. 


#### The solution

For backward compatibility, I've decided to bring all the settings into the existing attribute. Previously, the attribute was a simple `true` and `false` flag. Now the attribute still supports `true` and `false` but also allows specifying directly the attribute state `advanced` (= `true`) or `never` (new feature).


#### Todos

 * [ ] Related issues
 * [x] Tests
 * [x] Documentation